### PR TITLE
Link fixed on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,10 +477,9 @@ module.exports = {
 
 ### VS Code
 
-* [`mhmadhamster.postcss-language`] adds PostCSS and SugarSS support.
+* [`csstools.postcss`] adds PostCSS highlight.
 
-[`mhmadhamster.postcss-language`]: https://marketplace.visualstudio.com/items?itemName=mhmadhamster.postcss-language
-
+[`csstools.postcss`]: https://marketplace.visualstudio.com/items?itemName=csstools.postcss
 
 ### Atom
 


### PR DESCRIPTION
Changed VS Code plugin "mhmadhamster.postcss-language" in the "Editors & IDE Integration" section (no longer available in the VS Code store) for the  "csstools.postcss" plugin. The choice of the plugin was based strictly on criteria of popularity and positive ratings.